### PR TITLE
Adapt to Coq 8.18.0.

### DIFF
--- a/compcert/FreeSim.v
+++ b/compcert/FreeSim.v
@@ -261,7 +261,7 @@ Lemma event_step_follow_dstar L s0 s1 s2 t1 t2
 Proof.
   inv STAR.
   { symmetry in H1. eapply Eapp_E0_inv in H1.
-    destruct H1. subst. simpl in NNIL. intuition. }
+    destruct H1. subst. simpl in NNIL. auto with *. }
   destruct H as [DET STEP1].
   exploit DET.(sd_at_determ); [eapply STEP|eapply STEP1|..].
   intros [TR EQ]. destruct t1; simpl in NNIL; [lia|].

--- a/lib/AList.v
+++ b/lib/AList.v
@@ -13,8 +13,6 @@ Require Import Coqlib.
 Set Implicit Arguments.
 
 
-Global Opaque string_dec.
-
 (************ temporary buffer before putting it in Coqlib ***********)
 (************ temporary buffer before putting it in Coqlib ***********)
 (************ temporary buffer before putting it in Coqlib ***********)

--- a/lib/Any.v
+++ b/lib/Any.v
@@ -13,7 +13,7 @@ Module Type ANY.
   Parameter upcast_downcast: forall T (v: T), downcast (upcast v) = Some v.
   Parameter downcast_upcast: forall T (v: T) (a: t), downcast a = Some v -> <<CAST: upcast v = a>>.
   Parameter upcast_inj: forall A B (a: A) (b: B) (EQ: upcast a = upcast b),
-      <<EQ: A = B>> /\ <<EQ: a ~= b>>.
+      <<EQ: A = B>> /\ <<EQ: JMeq a b>>.
 
   Parameter pair: t -> t -> t.
   Parameter split: t -> option (t * t).
@@ -88,7 +88,7 @@ Module _Any: ANY.
         A B (a: A) (b: B)
         (EQ: upcast a = upcast b)
     :
-      <<EQ: A = B>> /\ <<EQ: a ~= b>>
+      <<EQ: A = B>> /\ <<EQ: JMeq a b>>
   .
   Proof. unfold upcast in *. simpl_depind. ss. Qed.
 

--- a/lib/Coqlib.v
+++ b/lib/Coqlib.v
@@ -668,8 +668,6 @@ Proof.
     des_ifs. ss. exploit (@IHn _ _ _ f); eauto.
 Qed.
 
-Global Opaque Z.mul.
-
 Lemma unit_ord_wf: well_founded (bot2: unit -> unit -> Prop).
 Proof. ii. induction a; ii; ss. Qed.
 

--- a/lib/Coqlib.v
+++ b/lib/Coqlib.v
@@ -680,25 +680,25 @@ Require Import Program.
 Lemma f_equal_h
       X1 X2 Y1 Y2 (f1: X1 -> Y1) (f2: X2 -> Y2) x1 x2
       (TYPX: X1 = X2)
-      (FUNC: f1 ~= f2)
-      (ARG: x1 ~= x2)
+      (FUNC: JMeq f1 f2)
+      (ARG: JMeq x1 x2)
       (TYPY: Y1 = Y2): (* Do we need this? *)
-    f1 x1 ~= f2 x2.
+    JMeq (f1 x1) (f2 x2).
 Proof. subst. eapply JMeq_eq in FUNC. subst. ss. Qed.
 
 Lemma f_equal_hr
       X1 X2 Y (f1: X1 -> Y) (f2: X2 -> Y) x1 x2
-      (FUNC: f1 ~= f2)
+      (FUNC: JMeq f1 f2)
       (TYP: X1 = X2)
-      (ARG: x1 ~= x2):
+      (ARG: JMeq x1 x2):
     f1 x1 = f2 x2.
 Proof. eapply JMeq_eq. eapply f_equal_h; eauto. Qed.
 
 Lemma f_equal_rh
       X Y1 Y2 (f1: X -> Y1) (f2: X -> Y2) x
-      (FUNC: f1 ~= f2)
+      (FUNC: JMeq f1 f2)
       (TYP: Y1 = Y2):
-    f1 x ~= f2 x.
+      JMeq (f1 x) (f2 x).
 Proof. eapply f_equal_h; eauto. Qed.
 
 Lemma cons_app
@@ -727,7 +727,7 @@ Proof. induction la; econs; ss. Qed.
 
 Lemma f_hequal A (B : A -> Type) (f : forall a, B a)
       a1 a2 (EQ : a1 = a2):
-    f a1 ~= f a2.
+      JMeq (f a1) (f a2).
 Proof. destruct EQ. econs. Qed.
 
 Ltac uo := unfold o_bind, o_bind2, o_map, o_join in *.

--- a/lib/sflib.v
+++ b/lib/sflib.v
@@ -723,7 +723,8 @@ Tactic Notation "extensionalities" ident(a) ident(b) ident(c) ident(d) ident(e) 
 
 (* short for common tactics *)
 
-Tactic Notation "inst" := instantiate.
+(* Deprecated in Coq 8.18 *)
+(* Tactic Notation "inst" := instantiate. *)
 Tactic Notation "econs" := econstructor.
 Tactic Notation "econs" int_or_var(x) := econstructor x.
 Tactic Notation "i" := intros.
@@ -787,16 +788,28 @@ Ltac clear_upto H :=
 
 Definition _Evar_sflib_ (A:Type) (x:A) := x.
 
-Tactic Notation "hide_evar" int_or_var(n) := let QQ := fresh "QQ" in
-  hget_evar n; intro;
-  lazymatch goal with [ H := ?X |- _] =>
-    set (QQ := X) in *; fold (_Evar_sflib_ X) in QQ; clear H
+(* Deprecated in Coq 8.18 *)
+(* Tactic Notation "hide_evar" int_or_var(n) := let QQ := fresh "QQ" in *)
+(*  hget_evar n; intro;                                                 *)
+(*  lazymatch goal with [ H := ?X |- _] =>                              *)
+(*    set (QQ := X) in *; fold (_Evar_sflib_ X) in QQ; clear H          *)
+(*  end.                                                                *)
+
+Ltac hide_evars :=
+  repeat match goal with
+  | [ |- context [?x] ] => is_evar x; set x;
+    lazymatch goal with [ H := x |- _ ] =>
+      fold (_Evar_sflib_ x) in H
+    end
   end.
 
-Ltac hide_evars := repeat (hide_evar 1).
-
-Ltac show_evars := repeat (match goal with [ H := @_Evar_sflib_ _ _ |- _ ] => unfold
- _Evar_sflib_ in H; unfold H in *; clear H end).
+Ltac show_evars :=
+  repeat match goal with
+  | [ H := @_Evar_sflib_ _ _ |- _ ] =>
+    unfold _Evar_sflib_ in H;
+    unfold H in *;
+    clear H
+  end.
 
 Ltac revert1 := match goal with [H: _|-_] => revert H end.
 

--- a/opam
+++ b/opam
@@ -31,11 +31,11 @@ tags: [
 ]
 
 depends: [
-  "coq" { >= "8.15" & < "8.16" }
-  "coq-paco" { (= "4.1.2") }
-  "coq-itree" { (= "4.0.0") }
-  "coq-ordinal" { (= "0.5.2") }
-  "coq-compcert" { (= "3.11") }
+  "coq" { >= "8.15" }
+  "coq-paco" { (>= "4.1.2") }
+  "coq-itree" { (>= "4.0.0") }
+  "coq-ordinal" { (>= "0.5.2") }
+  "coq-compcert" { (>= "3.11") }
 ]
 
 build: [make "-j%{jobs}%"]

--- a/sim/IRed.v
+++ b/sim/IRed.v
@@ -443,7 +443,8 @@ Section TEST.
 
   Local Set Typeclasses Depth 50.
 
-  Goal forall (itr: itree (void1 +' void1 +' eventE) nat), resum_itr (tau;; itr) = tau;; resum_itr itr.
+
+  Goal forall (itr: itree (void1 +' void1 +' eventE) nat), resum_itr (F := (void1 +' void1 +' eventE)) (tau;; itr) = tau;; resum_itr itr.
   Proof. i. Timeout 1 my_red_both. refl. Qed.
 
   Goal forall (itr: itree (void1 +' eventE) nat), resum_itr (F:= void1 +' eventE +' void1) (tau;; itr) = tau;; resum_itr itr.

--- a/sim/ModSem.v
+++ b/sim/ModSem.v
@@ -197,7 +197,7 @@ Section MODSEML.
   (* Qed. *)
 
 
-  Let itree_eta E R (itr0 itr1: itree E R)
+  Lemma itree_eta E R (itr0 itr1: itree E R)
       (OBSERVE: observe itr0 = observe itr1)
     :
       itr0 = itr1.
@@ -307,7 +307,7 @@ Section MODSEML.
 
   Context {CONF: EMSConfig}.
 
-  Let add_comm_aux
+  Lemma add_comm_aux
       ms0 ms1 stl0 str0
       P
       (SIM: stl0 = str0)

--- a/sim/ModSemE.v
+++ b/sim/ModSemE.v
@@ -80,8 +80,8 @@ Notation "f '?'" := (unwrapU f) (at level 9, only parsing).
 Notation "f 'ǃ'" := (unwrapN f) (at level 9, only parsing).
 Notation "(?)" := (unwrapU) (only parsing).
 Notation "(ǃ)" := (unwrapN) (only parsing).
-Goal (tt ↑↓?) = Ret tt. rewrite Any.upcast_downcast. ss. Qed.
-Goal (tt ↑↓ǃ) = Ret tt. rewrite Any.upcast_downcast. ss. Qed.
+Goal (unwrapU (E := eventE) (tt ↑↓)) = Ret tt. rewrite Any.upcast_downcast. ss. Qed.
+Goal (unwrapN (E := eventE) (tt ↑↓)) = Ret tt. rewrite Any.upcast_downcast. ss. Qed.
 
 
 

--- a/sim/SimGlobalIndexFacts.v
+++ b/sim/SimGlobalIndexFacts.v
@@ -440,6 +440,8 @@ Proof.
 Qed.
 
 Section EUTT.
+#[local] Hint Unfold eqit euttge : core.
+
 
 Theorem eutt_simg: forall R0 R1 RR (u: itree (E +' eventE) R0) (t: itree (E +' eventE) R1) (EUTT: eqit RR true true u t),
     simg (fun _ _ => RR) 0%ord 0%ord u t.
@@ -1135,6 +1137,7 @@ Qed.
 
 End TRANS.
 
+#[local] Hint Constructors eqitF : core.
 
 Section DUAL.
 
@@ -1336,6 +1339,7 @@ Section DUAL.
                       end)) (fun x => dualize2 (ktr x))
       end.
   Proof. unfold dualize2. ides itr; ss. destruct e; ss. Qed.
+
 
   Lemma dualize2_involution
         R (itr: itree (E +' eventE) R)

--- a/sim/Skeleton.v
+++ b/sim/Skeleton.v
@@ -272,7 +272,7 @@ Module Sk.
       uo. destruct p. exists s. ss. }
     destruct sk; ss; clarify.
     { lia. }
-    apply lt_S_n in BLKRANGE. eapply IHblk; eauto.
+    apply Nat.succ_lt_mono in BLKRANGE. eapply IHblk; eauto.
   Qed.
 
   Lemma env_found_range :
@@ -285,7 +285,7 @@ Module Sk.
     { apply Nat.lt_0_succ. }
     destruct blk.
     { apply Nat.lt_0_succ. }
-    uo. des_ifs. destruct p. ss. clarify. apply lt_n_S. eapply IHsk; eauto.
+    uo. des_ifs. destruct p. ss. clarify. apply -> Nat.succ_lt_mono. eapply IHsk; eauto.
     instantiate (1:=symb). rewrite Heq0. ss.
   Qed.
 


### PR DESCRIPTION
FreeSim was originally configured to work only with Coq 8.15.2. This pull request relaxes this limitation, allowing for Coq versions between 8.15 and 8.18. 

Some files were modified to compile with higher versions. The change in ```sflib.v``` follows the modification in the sflib repo (https://github.com/snu-sf/sflib/commit/9a58d400c5678a75da494d7fb38588be5f701f98). Other changes are minor.

I am using FreeSim for a project in the KAIST CP lab, and it would help me a lot if a FreeSim version that supports higher Coq versions is published.

## Tests
The version was checked to compile with the two settings below.
```
coq 8.18.0
coq-itree 5.2.0
coq-paco 4.2.0
coq-ordinal 0.5.3
coq-compcert 3.14
```

```
coq 8.15.2
coq-itree 4.0.0
coq-paco 4.1.2
coq-ordinal 0.5.2
coq-compcert 3.11
```